### PR TITLE
update: session counter test to use new atomic counter

### DIFF
--- a/cuid2.go
+++ b/cuid2.go
@@ -151,13 +151,6 @@ func WithFingerprint(fingerprint string) Option {
 	}
 }
 
-func createCounter(initialCount int64) func() int64 {
-	return func() int64 {
-		initialCount++
-		return initialCount - 1
-	}
-}
-
 func createFingerprint(randomFunc func() float64, envKeyString string) string {
 	sourceString := createEntropy(MaxIdLength, randomFunc)
 

--- a/cuid2_test.go
+++ b/cuid2_test.go
@@ -66,13 +66,13 @@ func TestGeneratingCuidWithMaxLength(t *testing.T) {
 // Internal Tests
 func TestSessionCounter(t *testing.T) {
 	var initialSessionCount int64 = 10
-	sessionCounter := createCounter(initialSessionCount)
-	expectedCounts := []int64{10, 11, 12, 13}
+	sessionCounter := NewSessionCounter(initialSessionCount)
+	expectedCounts := []int64{11, 12, 13, 14}
 	actualCounts := []int64{
-		sessionCounter(),
-		sessionCounter(),
-		sessionCounter(),
-		sessionCounter(),
+		sessionCounter.Increment(),
+		sessionCounter.Increment(),
+		sessionCounter.Increment(),
+		sessionCounter.Increment(),
 	}
 
 	for index, actualCount := range actualCounts {


### PR DESCRIPTION
## What's changed
- Updated session counter test to use new atomic counter

## Why
- It was still using the old method

## Test Results
```
2023/09/17 16:38:25 Sample Cuids: [tjdqtzang308udsi7aown959 g9wyn37urujqwf34ok4in9ox vulhpbdw81gexfww4xlgtbry bhypcl561xlcx7q5mqcoez6x zwq967miwu10hfr7l9et0m77 ja1qu149umd9qqmvw3h7jq88 r2vvxcue2xjw27ufs6w9r1kz ezuc35tw3rm16qm2axc6kfb9 fn44wpv4426w95m9oys491of vzsawovzuff52bny3mj8l73b]
2023/09/17 16:38:25 Histogram: [83200 82245 83230 82994 82846 82788 83553 82852 83257 82835 83510 82886 82917 82320 81578 80887 81357 80625 80615 80591]
2023/09/17 16:38:25 Expected bin size: 82354
2023/09/17 16:38:25 Min bin size: 78236
2023/09/17 16:38:25 Maximum bin size: 86472
2023/09/17 16:38:25 Validating all 11529602 Cuids...
PASS
ok      github.com/nrednav/cuid2        22.327s
```