### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed validation of non-CUID strings by `IsCuid()`
   - Added new criteria (starts with a letter) to the validation regex
+- Fixed security alert for `crypto` package
+  - Updated from v0.10.0 to v0.17.0 via Dependabot
 
 ## [v1.0.0] - 2023-09-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v1.0.1] - 2024-10-26
+
+### Fixed
+
+- Fixed validation of non-CUID strings by `IsCuid()`
+  - Added new criteria (starts with a letter) to the validation regex
+
+## [v1.0.0] - 2023-09-17
+
+- First release

--- a/cuid2.go
+++ b/cuid2.go
@@ -99,7 +99,7 @@ var Generate, _ = Init()
 // Checks whether a given Cuid has a valid form and length
 func IsCuid(cuid string) bool {
 	length := len(cuid)
-	hasValidForm, _ := regexp.MatchString("^[0-9a-z]+$", cuid)
+	hasValidForm, _ := regexp.MatchString("^[a-z][0-9a-z]+$", cuid)
 
 	if hasValidForm && length >= MinIdLength && length <= MaxIdLength {
 		return true

--- a/cuid2_test.go
+++ b/cuid2_test.go
@@ -11,6 +11,11 @@ func TestIsCuid(t *testing.T) {
 		Generate():                           true,  // Default
 		Generate() + Generate() + Generate(): false, // Too Long
 		"":                                   false, // Too Short
+		"42":                                 false, // Non-CUID
+		"aaaaDLL":                            false, // Capital letters
+		"yi7rqj1trke":                        true,  // Valid
+		"-x!ha":                              false, // Invalid characters
+		"ab*%@#x":                            false, // Invalid characters
 	}
 
 	for testCase, expected := range testCases {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/nrednav/cuid2
 
 go 1.20
 
-require golang.org/x/crypto v0.10.0
+require golang.org/x/crypto v0.17.0
 
-require golang.org/x/sys v0.9.0 // indirect
+require golang.org/x/sys v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-golang.org/x/crypto v0.10.0 h1:LKqV2xt9+kDzSTfOhx4FrkEBcMrAgHSYgzywV9zcGmM=
-golang.org/x/crypto v0.10.0/go.mod h1:o4eNf7Ede1fv+hwOwZsTHl9EsPFO6q6ZvYR8vYfY45I=
-golang.org/x/sys v0.9.0 h1:KS/R3tvhPqvJvwcKfnBHJwwthS11LRhmM5D59eEXa0s=
-golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
+golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
+golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
## What's changed
- Updated validation regex for `IsCuid()` to include new criteria (must start with a letter)
- Updated `crypto` package to v0.17.0 via Dependabot
- Added a changelog

## Why
- It was reported in https://github.com/paralleldrive/cuid2/issues/79 that `IsCuid()` would incorrectly validate non-CUID strings such as `42`
- A fix was added in https://github.com/paralleldrive/cuid2/commit/768d132d559c712c26d6ccc26a2895c3c180b60c

## Results
### Test
![image](https://github.com/user-attachments/assets/85d21b72-0022-456d-a854-49ee2872d563)

### Histogram
```
2024/10/26 04:31:39 Histogram: [82708 82655 83543 83010 83014 82710 83146 82969 82930 82948 83401 83072 82507 82775 81063 81026 80856 81185 80604 80964]
```
![image](https://github.com/user-attachments/assets/3a3c5d60-536d-4d92-80c9-a27b3c4a9c03)


### Benchmark
![image](https://github.com/user-attachments/assets/aa0bf02c-9837-4843-af82-d8902352eb0f)