### PR TITLE
[FEATURE] adds InitChan() to create a chan generator

### DIFF
--- a/cuid2_test.go
+++ b/cuid2_test.go
@@ -90,6 +90,27 @@ func TestSessionCounter(t *testing.T) {
 	}
 }
 
+func TestUnsafeSessionCounter(t *testing.T) {
+	var initialSessionCount int64 = 10
+	sessionCounter := NewUnsafeSessionCounter(initialSessionCount)
+	expectedCounts := []int64{11, 12, 13, 14}
+	actualCounts := []int64{
+		sessionCounter.Increment(),
+		sessionCounter.Increment(),
+		sessionCounter.Increment(),
+		sessionCounter.Increment(),
+	}
+
+	for index, actualCount := range actualCounts {
+		expectedCount := expectedCounts[index]
+		if actualCount != expectedCount {
+			t.Error("Expected session counts to increment by one for each successive call")
+			t.Errorf("For an initial session count of %v, expected %v", initialSessionCount, expectedCounts)
+			t.Fatalf("Got %v", actualCounts)
+		}
+	}
+}
+
 func TestCreatingFingerprintWithEnvKeyString(t *testing.T) {
 	fingerprint := createFingerprint(rand.Float64, getEnvironmentKeyString())
 	if len(fingerprint) < MinIdLength {
@@ -103,5 +124,34 @@ func TestCreatingFingerprintWithoutEnvKeyString(t *testing.T) {
 	if len(fingerprint) < MinIdLength {
 		t.Error("Could not generate fingerprint of adequate length")
 		t.Fatalf("Expected length to be at least %v, but got %v", MinIdLength, len(fingerprint))
+	}
+}
+
+func TestGeneratingDefaultFromChan(t *testing.T) {
+	ch, _, _ := InitChan()
+
+	for i := 0; i < 100; i++ {
+		cuid := <-ch
+
+		if len(cuid) != DefaultIdLength {
+			t.Fatalf("Expected default Cuid length to be %v, but got %v", DefaultIdLength, len(cuid))
+		}
+	}
+}
+
+func TestGeneratingCustomLengthFromChan(t *testing.T) {
+	customLength := 16
+	ch, _, err := InitChan(WithLength(customLength))
+
+	if err != nil {
+		t.Fatalf("Expected to initialize cuid2 chan generator but received error = %v", err.Error())
+	}
+
+	for i := 0; i < 100; i++ {
+		cuid := <-ch
+
+		if len(cuid) != customLength {
+			t.Fatalf("Expected to generate Cuid with a custom length of %v, but got %v", customLength, len(cuid))
+		}
 	}
 }


### PR DESCRIPTION
Hi @nrednav 

I was having a look at your port, and saw the use of `sync/atomic` for the session counter.
I figured this could be a bottleneck for use cases where a lot of Cuids need to be generated by several goroutines.

The proposition is to add an `InitChan()` func which returns a channel from which cuids can be received.
The buffer size of the channel can be configured, and defaults to 10.
`InitChan()` also returns a cancel function, which stops the generation of new Cuids.
A specific `Context` can also be configured (e.g. an HTTP request Context), which will stop the generation as soon as the `Context` is done.

What do you think?
Feel free to make the changes you want to or tell me what changes would be necessary to merge this.

Cheers!